### PR TITLE
Make Linux installer portable across apt and dnf distros

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,13 +8,26 @@ on:
 
 jobs:
 
-  linux:
-    name: Build
+  ubuntu:
+    name: Build (Ubuntu)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: prompt
         run: |
           sudo apt-get update
-          sudo apt-get upgrade
+          sudo apt-get upgrade -y
+          bash ./setup.sh --force
+
+  fedora:
+    name: Build (Fedora)
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - name: prerequisites
+        run: |
+          dnf -y install git sudo util-linux which
+      - uses: actions/checkout@v4
+      - name: prompt
+        run: |
           bash ./setup.sh --force

--- a/setup.sh
+++ b/setup.sh
@@ -4,9 +4,21 @@ set -eu
 
 function install() {
 
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then        
-        sudo add-apt-repository -y ppa:aslatter/ppa
-        INSTALL="sudo apt-get -y install"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if command -v apt-get >/dev/null 2>&1; then
+            # Debian / Ubuntu
+            sudo add-apt-repository -y ppa:aslatter/ppa || echo "[WARN] could not add aslatter PPA, continuing..."
+            INSTALL="sudo apt-get -y install"
+        elif command -v dnf >/dev/null 2>&1; then
+            # Fedora / RHEL / Amazon Linux 2023
+            INSTALL="sudo dnf -y install"
+        elif command -v yum >/dev/null 2>&1; then
+            # Older RHEL / CentOS
+            INSTALL="sudo yum -y install"
+        else
+            echo "[ERROR] No supported package manager found (apt-get, dnf, yum)"
+            exit 1
+        fi
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         which brew > /dev/null || bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
         INSTALL="brew install"
@@ -14,9 +26,11 @@ function install() {
         echo "OS not supported"
         exit 1
     fi
-    
-    # Install packages, allowing graceful failure for each
-    for pkg in zsh wget vim bat cyme ripgrep gh fzf; do
+
+    # Install packages, allowing graceful failure for each.
+    # cyme isn't packaged on most distros — falls through to the warning and
+    # can be installed later via `cargo install cyme` if desired.
+    for pkg in zsh wget vim bat ripgrep gh fzf cyme; do
         $INSTALL $pkg || echo "[WARN] Failed to install $pkg, continuing..."
     done
 


### PR DESCRIPTION
setup.sh now detects apt-get / dnf / yum and picks the right installer,
so the script works on Fedora, RHEL, and Amazon Linux 2023 in addition
to Debian/Ubuntu. Graceful failure on individual packages is preserved,
and cyme (rarely packaged) was moved to the end of the install loop.

CI: split the linux workflow into separate ubuntu and fedora jobs so the
dnf branch is exercised on every change. Bumped actions/checkout to v4.
